### PR TITLE
UI tweaks

### DIFF
--- a/plugins/scaffolder-react/src/next/components/Workflow/Workflow.tsx
+++ b/plugins/scaffolder-react/src/next/components/Workflow/Workflow.tsx
@@ -97,6 +97,27 @@ export const Workflow = (workflowProps: WorkflowProps): JSX.Element | null => {
       {manifest && (
         <InfoCard
           title={title ?? manifest.title}
+          action={
+            manifest.type === workflow_type &&
+            manifest.name && (
+              <>
+                <Button
+                  variant="contained"
+                  color="secondary"
+                  style={{ marginTop: 8, marginRight: 8 }}
+                  onClick={_ => setOpen(true)}
+                >
+                  View {workflow_title}
+                </Button>
+                <SWFDialog
+                  swfId={manifest.name}
+                  title={manifest.title}
+                  open={open}
+                  close={() => setOpen(false)}
+                />
+              </>
+            )
+          }
           subheader={
             <MarkdownContent
               className={styles.markdown}
@@ -106,23 +127,6 @@ export const Workflow = (workflowProps: WorkflowProps): JSX.Element | null => {
           noPadding
           titleTypographyProps={{ component: 'h2' }}
         >
-          {manifest.type === workflow_type && manifest.name && (
-            <>
-              <Button
-                variant="contained"
-                color="primary"
-                onClick={_ => setOpen(true)}
-              >
-                View {workflow_title}
-              </Button>
-              <SWFDialog
-                swfId={manifest.name}
-                title={manifest.title}
-                open={open}
-                close={() => setOpen(false)}
-              />
-            </>
-          )}
           <Stepper manifest={manifest} templateName={templateName} {...props} />
         </InfoCard>
       )}

--- a/plugins/swf/src/components/CreateSWFPage/CreateSWFPage.tsx
+++ b/plugins/swf/src/components/CreateSWFPage/CreateSWFPage.tsx
@@ -125,16 +125,14 @@ export const CreateSWFPage = () => {
           <Grid item>
             {loading && <Progress />}
             <InfoCard
-              title={
-                <>
-                  <Typography variant="h5">
-                    Author - Example of how we could support authoring
-                  </Typography>
+              action={
+                swfEditor?.isReady && (
                   <Button
                     color="primary"
                     type="submit"
                     variant="contained"
                     disabled={loading}
+                    style={{ marginTop: 8, marginRight: 8 }}
                     onClick={() => {
                       swfEditor?.getContent().then(content => {
                         if (content) {
@@ -143,12 +141,17 @@ export const CreateSWFPage = () => {
                       });
                     }}
                   >
-                    Save...
+                    Save
                   </Button>
-                </>
+                )
+              }
+              title={
+                <Typography variant="h5">
+                  Author - Example of how we could support authoring
+                </Typography>
               }
             >
-              <div style={{ height: '500px', padding: '10px' }}>
+              <div style={{ height: '600px', padding: '10px' }}>
                 <SWFEditor
                   ref={swfEditorRef}
                   kind={EditorViewKind.AUTHORING}

--- a/plugins/swf/src/components/SWFDefinitionViewerPage/SWFDefinitionViewerPage.tsx
+++ b/plugins/swf/src/components/SWFDefinitionViewerPage/SWFDefinitionViewerPage.tsx
@@ -63,10 +63,10 @@ export const SWFDefinitionViewerPage = () => {
           <Grid item>
             {loading && <Progress />}
             <InfoCard title={name || ''}>
-              <div style={{ height: '500px' }}>
+              <div style={{ height: '600px' }}>
                 <SWFEditor
                   ref={swfEditorRef}
-                  kind={EditorViewKind.DIAGRAM_VIEWER}
+                  kind={EditorViewKind.EXTENDED_DIAGRAM_VIEWER}
                   swfId={swfId}
                 />
               </div>

--- a/plugins/swf/src/components/SWFDialog/SWFDialog.tsx
+++ b/plugins/swf/src/components/SWFDialog/SWFDialog.tsx
@@ -14,9 +14,18 @@
  * limitations under the License.
  */
 import React from 'react';
-import { Dialog, DialogTitle } from '@material-ui/core';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  Box,
+  makeStyles,
+  IconButton,
+  Typography,
+} from '@material-ui/core';
 import { SWFEditor } from '../SWFEditor';
 import { EditorViewKind } from '../SWFEditor/SWFEditor';
+import CloseIcon from '@material-ui/icons/Close';
 
 type SWFDialogProps = {
   swfId: string;
@@ -24,15 +33,45 @@ type SWFDialogProps = {
   open: boolean;
   close: () => void;
 };
+
+const useStyles = makeStyles(_theme => ({
+  editor: {
+    height: '600px',
+    marginBottom: 20,
+  },
+  closeBtn: {
+    position: 'absolute',
+    right: 8,
+    top: 8,
+  },
+}));
+
 export const SWFDialog = (props: SWFDialogProps): JSX.Element | null => {
   const { swfId, title, open, close } = props;
+  const classes = useStyles();
 
   return (
-    <Dialog onClose={_ => close()} open={open}>
-      <DialogTitle>{title}</DialogTitle>
-      <div style={{ height: '500px', width: '500px', padding: '10px' }}>
-        <SWFEditor kind={EditorViewKind.DIAGRAM_VIEWER} swfId={swfId} />
-      </div>
+    <Dialog fullWidth maxWidth="lg" onClose={_ => close()} open={open}>
+      <DialogTitle>
+        <Box>
+          <Typography variant="h5">{title}</Typography>
+          <IconButton
+            className={classes.closeBtn}
+            aria-label="close"
+            onClick={close}
+          >
+            <CloseIcon />
+          </IconButton>
+        </Box>
+      </DialogTitle>
+      <DialogContent>
+        <Box className={classes.editor}>
+          <SWFEditor
+            kind={EditorViewKind.EXTENDED_DIAGRAM_VIEWER}
+            swfId={swfId}
+          />
+        </Box>
+      </DialogContent>
     </Dialog>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4757,6 +4757,7 @@ __metadata:
     "@backstage/cli": "workspace:^"
     "@backstage/config": "workspace:^"
     "@backstage/config-loader": "workspace:^"
+    "@backstage/plugin-app-node": "workspace:^"
     "@backstage/types": "workspace:^"
     "@types/express": ^4.17.6
     "@types/supertest": ^2.0.8
@@ -4774,6 +4775,17 @@ __metadata:
     supertest: ^6.1.3
     winston: ^3.2.1
     yn: ^4.0.0
+  languageName: unknown
+  linkType: soft
+
+"@backstage/plugin-app-node@workspace:^, @backstage/plugin-app-node@workspace:plugins/app-node":
+  version: 0.0.0-use.local
+  resolution: "@backstage/plugin-app-node@workspace:plugins/app-node"
+  dependencies:
+    "@backstage/backend-plugin-api": "workspace:^"
+    "@backstage/cli": "workspace:^"
+    "@types/express": ^4.17.6
+    express: ^4.17.1
   languageName: unknown
   linkType: soft
 
@@ -7603,6 +7615,7 @@ __metadata:
     "@backstage/config": "workspace:^"
     "@backstage/errors": "workspace:^"
     "@backstage/plugin-auth-node": "workspace:^"
+    "@backstage/plugin-catalog-node": "workspace:^"
     "@backstage/plugin-linguist-common": "workspace:^"
     "@backstage/types": "workspace:^"
     "@types/express": "*"
@@ -7610,6 +7623,7 @@ __metadata:
     express: ^4.18.1
     express-promise-router: ^4.1.0
     fs-extra: ^10.0.0
+    js-yaml: ^4.1.0
     knex: ^2.0.0
     linguist-js: ^2.5.3
     luxon: ^2.0.2
@@ -8173,8 +8187,10 @@ __metadata:
   dependencies:
     "@backstage/backend-common": "workspace:^"
     "@backstage/backend-plugin-api": "workspace:^"
+    "@backstage/backend-test-utils": "workspace:^"
     "@backstage/cli": "workspace:^"
     "@backstage/config": "workspace:^"
+    "@backstage/config-loader": "workspace:^"
     "@types/express": ^4.17.6
     "@types/http-proxy-middleware": ^0.19.3
     "@types/supertest": ^2.0.8
@@ -26209,6 +26225,7 @@ __metadata:
     "@backstage/plugin-permission-backend": "workspace:^"
     "@backstage/plugin-permission-common": "workspace:^"
     "@backstage/plugin-permission-node": "workspace:^"
+    "@backstage/plugin-proxy-backend": "workspace:^"
     "@backstage/plugin-scaffolder-backend": "workspace:^"
     "@backstage/plugin-search-backend": "workspace:^"
     "@backstage/plugin-search-backend-module-catalog": "workspace:^"


### PR DESCRIPTION
- Move "View Workflow" button to the actions section of the card (top right) and use a secondary color on it.
- Move "Save" button to the actions section of the card (top right)
- Increase the height of the authoring/viewer editor a little bit
- Increase the size of the dialog viewer
- Enable the workflow source on the viewers but hidden as default
- yarn.lock needed update