### PR TITLE
Fix load instances

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -200,7 +200,7 @@ swf:
       host: ${JIRA_HOST}
       bearerToken: ${JIRA_BEARER_TOKEN}
   editor:
-    path: https://kiegroup.github.io/kogito-online/swf-chrome-extension/0.31.0
+    path: https://start.kubesmarts.org
 
 integrations:
   github:

--- a/plugins/swf-common/src/models.ts
+++ b/plugins/swf-common/src/models.ts
@@ -71,7 +71,7 @@ export interface ProcessInstance {
   serviceUrl?: string;
   nodes: NodeInstance[];
   milestones?: Milestone[];
-  variables?: string;
+  variables?: Record<string, unknown>;
   start: Date;
   end?: Date;
   parentProcessInstance?: ProcessInstance;

--- a/plugins/swf/src/components/SWFInstancesViewerPage/SWFInstancesViewerPage.tsx
+++ b/plugins/swf/src/components/SWFInstancesViewerPage/SWFInstancesViewerPage.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { useCallback, useState } from 'react';
+import React, { useState } from 'react';
 import {
   Content,
   ContentHeader,
@@ -32,11 +32,6 @@ import { ProcessTimeline } from './ProcessTimeline';
 
 export const SWFInstancesViewerPage = () => {
   const [selectedInstance, setSelectedInstance] = useState<ProcessInstance>();
-
-  const toJsonVariables = useCallback(() => {
-    const variables: string | undefined = selectedInstance?.variables;
-    return variables ? JSON.parse(variables) : undefined;
-  }, [selectedInstance]);
 
   return (
     <Page themeId="tool">
@@ -67,7 +62,9 @@ export const SWFInstancesViewerPage = () => {
           <Grid item xs={12} lg={8}>
             <Grid container direction="row">
               <Grid item xs={12}>
-                <ProcessVariablesViewer variables={toJsonVariables()} />
+                <ProcessVariablesViewer
+                  variables={selectedInstance?.variables}
+                />
               </Grid>
               <Grid item xs={12}>
                 <ProcessTimeline selectedInstance={selectedInstance} />


### PR DESCRIPTION
`variables` property started to come as object, not string anymore.
Also, using kubesmarts URL for the envelope to fix node coloring.