### PR TITLE
Add `transitionIssue` operation to JIRA Open API

### DIFF
--- a/plugins/swf-backend/workflows/specs/jira-openapi.json
+++ b/plugins/swf-backend/workflows/specs/jira-openapi.json
@@ -1,8 +1,8 @@
 {
   "openapi": "3.0.1",
   "info": {
-    "title": "Workflow Actions for BS API",
-    "description": "Workflow Actions BS API",
+    "title": "JIRA Actions for BS API",
+    "description": "JIRA Actions BS API",
     "version": "0.0.1"
   },
   "servers": [
@@ -13,9 +13,7 @@
   "paths": {
     "/rest/api/2/issue": {
       "post": {
-        "tags": [
-          "Issues"
-        ],
+        "tags": ["Issues"],
         "summary": "Create issue",
         "description": "Creates an issue or, where the option to create subtasks is enabled in Jira, a subtask. A transition may be applied, to move the issue or subtask to a workflow step other than the default start step, and issue properties set.\n\nThe content of the issue or subtask is defined using `update` and `fields`. The fields that can be set in the issue or subtask are determined using the [ Get create issue metadata](#api-rest-api-3-issue-createmeta-get). These are the same fields that appear on the issue's create screen. Note that the `description`, `environment`, and any `textarea` type custom fields (multi-line text fields) take Atlassian Document Format content. Single line custom fields (`textfield`) accept a string and don't handle Atlassian Document Format content.\n\nCreating a subtask differs from creating an issue as follows:\n\n *  `issueType` must be set to a subtask issue type (use [ Get create issue metadata](#api-rest-api-3-issue-createmeta-get) to find subtask issue types).\n *  `parent` must contain the ID or key of the parent issue.\n\nIn a next-gen project any issue may be made a child providing that the parent and child are members of the same project.\n\n**[Permissions](#permissions) required:** *Browse projects* and *Create issues* [project permissions](https://confluence.atlassian.com/x/yodKLg) for the project in which the issue or subtask is created.",
         "operationId": "createIssue",
@@ -31,7 +29,7 @@
           }
         ],
         "requestBody": {
-          "description": "Input parameters for the action fetch:plain in BS",
+          "description": "Input parameters for the action createIssue in BS",
           "required": true,
           "content": {
             "application/json": {
@@ -60,22 +58,102 @@
           }
         ]
       }
+    },
+
+    "/rest/api/3/issue/{issueIdOrKey}/transitions": {
+      "post": {
+        "tags": ["Issues"],
+        "summary": "Transition issue",
+        "description": "Performs an issue transition and, if the transition has a screen, updates the fields from the transition screen.",
+        "operationId": "transitionIssue",
+        "parameters": [
+          {
+            "name": "issueIdOrKey",
+            "in": "path",
+            "description": "The ID or key of the issue.",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "description": "Input parameters for the action transitionIssue in BS",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TransitionIssue"
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "Transition Issue Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false,
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
     }
   },
   "components": {
     "securitySchemes": {
-      "basicAuth" : {
+      "basicAuth": {
         "type": "http",
         "scheme": "basic"
       },
-      "bearerAuth" : {
+      "bearerAuth": {
         "type": "http",
         "scheme": "bearer"
       }
     },
     "schemas": {
-      "ErrorCollection":{"type":"object"},
-      "IssueUpdateDetails":{"type":"object","properties":{"fields":{"type":"object"}}},
+      "ErrorCollection": { "type": "object" },
+      "IssueUpdateDetails": {
+        "type": "object",
+        "properties": { "fields": { "type": "object" } }
+      },
+      "TransitionIssue": {
+        "type": "object",
+        "properties": {
+          "transition": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "string" }
+            }
+          },
+          "update": {
+            "type": "object",
+            "properties": {
+              "comment": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "add": {
+                      "type": "object",
+                      "properties": {
+                        "body": { "type": "string" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
       "CreatedIssue": {
         "type": "object",
         "properties": {


### PR DESCRIPTION
Function usage example

```yaml
      - name: close the jira issue
        functionRef:
          refName: jiraCloseIssue
          arguments:
            issueIdOrKey: .jiraCreateIssueResult.id
            transition:
              id: '41'
            update:
              comment:
                - add:
                  body: Issue closed due to time out
```